### PR TITLE
Fix for data corruption issue, an enhancement, and typo corrections

### DIFF
--- a/views/admin.php
+++ b/views/admin.php
@@ -111,7 +111,7 @@
                 List Item Template
             </th>
             <td>
-                <textarea wrap="off" class="wpgh-textarea" name="wpgh_template" <?php echo $wpgh_template; ?></textarea>
+                <textarea wrap="off" class="wpgh-textarea" name="wpgh_template"><?php echo $wpgh_template; ?></textarea>
             </td>
             <td>
                 This template will be output for every project that comes back 

--- a/views/admin.php
+++ b/views/admin.php
@@ -128,7 +128,7 @@
         </tr>
         <tr>
             <td>
-                Pre-List Markup (HTML)
+                Post-List Markup (HTML)
             </td>
             <td>
                 <input name="wpgh_closer" type="text" value="<?php echo $wpgh_closer; ?>" />

--- a/views/admin.php
+++ b/views/admin.php
@@ -96,9 +96,9 @@
 <form method="post" action="<?php $_SERVER['PHP_SELF']; ?>">
     <table id="wpgh-settings">
         <tr>
-            <td>
+            <th scope="row">
                 Pre-List Markup (HTML)
-            </td>
+            </th>
             <td>
                 <input name="wpgh_opener" type="text" value="<?php echo $wpgh_opener; ?>" />
             </td>
@@ -107,9 +107,9 @@
             </td>
         </tr>
         <tr>
-            <td>
+            <th scope="row">
                 List Item Template
-            </td>
+            </th>
             <td>
                 <textarea wrap="off" class="wpgh-textarea" name="wpgh_template" <?php echo $wpgh_template; ?></textarea>
             </td>
@@ -127,9 +127,9 @@
             </td>
         </tr>
         <tr>
-            <td>
+            <th scope="row">
                 Post-List Markup (HTML)
-            </td>
+            </th>
             <td>
                 <input name="wpgh_closer" type="text" value="<?php echo $wpgh_closer; ?>" />
             </td>
@@ -138,9 +138,9 @@
             </td>
         </tr>
         <tr>
-            <td>
+            <th scope="row">
                 Save
-            </td>
+            </th>
             <td>
                 <input name="wpgh_submit" type="submit" value="Save!" />
             </td>

--- a/wordpress-github.php
+++ b/wordpress-github.php
@@ -166,7 +166,7 @@ class WPGH_Widget extends WP_Widget
      }
 
      /**
-      * Display the widget ont he sidebar
+      * Display the widget on the sidebar
       * @param array $args
       * @param array $instance
       */


### PR DESCRIPTION
This pull request contains a bug fix for data corruption, an enhancement, and a few typo corrections. 

In order of importance:

Bug fix:

1) The textarea tag in admin.php wasn't closed before the initial value, so characters before the first ">" in the input stream were lost, since it was consuming that as the closing tag for the textarea.

Enhancement:

2) Adds row headers in admin.php to assist screen readers and improve visability, and also scopes them to conform to HTML5.

Typo corrections:

3) Corrected a minor typo in admin.php. The typo resulted in the duplication of the "Pre-List Markup (HTML)" <td> , instead of the intended "Post-List Markup (HTML)" <td>.

4) Corrects a minor typo in a comment.
