### PR TITLE
HTML Entity escaping

### DIFF
--- a/wordpress-github.php
+++ b/wordpress-github.php
@@ -55,9 +55,9 @@ class WPGH_Core
         {
             $template = self::getProjectTemplate();
             $template = str_replace('{{PROJECT_URL}}', $project->url, $template);
-            $template = str_replace('{{PROJECT_NAME}}', $project->name, $template);
+            $template = str_replace('{{PROJECT_NAME}}', htmlentities($project->name), $template);
             $template = str_replace('{{PROJECT_WATCHER_COUNT}}', $project->watchers, $template);
-            $template = str_replace('{{PROJECT_DESCRIPTION}}', $project->description, $template);
+            $template = str_replace('{{PROJECT_DESCRIPTION}}', htmlentities($project->description), $template);
             $template = str_replace('{{PROJECT_SOURCE}}', $project->source, $template);
             $template = str_replace('{{PROJECT_WATCHER_NOUN}}', $project->watcher_noun, $template);
 


### PR DESCRIPTION
Quick fix for HTML Entity escaping... rendering breaks if tags are included from git feed in project titles or descriptions
