### PR TITLE
Set user agent string. Fixes GitHub not working issue (#14)

### DIFF
--- a/lib/Net.php
+++ b/lib/Net.php
@@ -26,8 +26,11 @@ class WPGH_Net
             else return '';
         }
 
-        $curl_handle = curl_init($url);
+        $curl_handle  = curl_init($url);
+        $curl_version = curl_version();
+
         $options    += array(CURLOPT_RETURNTRANSFER => true);
+        $options    += array(CURLOPT_USERAGENT      => "curl/".$curl_version[version]);
 
         curl_setopt_array($curl_handle, $options);
 


### PR DESCRIPTION
- GitHub started to block requests without an user agent.
  See http://developer.github.com/v3/#user-agent-required
- Set the user agent to curl/$curl_version_number
- Fixes the GitHub not working issue (#14)
